### PR TITLE
test: add test for running Renovate in dry-run mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,19 @@ jobs:
         run: npm ci --ignore-scripts
       - name: Lint
         run: npm run lint
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
+      - name: Renovate
+        uses: renovatebot/github-action@v23.40.1
+        with:
+          configurationFile: test/renovate-config.js
+          token: ${{ secrets.RENOVATE_TOKEN }}
   release:
-    needs: lint
+    needs: [lint, test]
     runs-on: ubuntu-latest
     # GitHub API requests can easy take a couple of seconds and the release can
     # make lots of API requests when a release has a lot of commits. If every

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.3
-      - name: Renovate
+      - name: Test
         uses: renovatebot/github-action@v23.40.1
         with:
           configurationFile: test/renovate-config.js

--- a/test/renovate-config.js
+++ b/test/renovate-config.js
@@ -1,0 +1,7 @@
+const config = require('../src/renovate-config');
+
+module.exports = {
+  ...config,
+  dryRun: true,
+  logLevel: 'debug',
+};


### PR DESCRIPTION
The test uses the same config as the normal Renovate workflow with only dry-run and logging configuration changed.